### PR TITLE
Add Data object array to the Content object

### DIFF
--- a/openrtb-core/src/main/protobuf/openrtb.proto
+++ b/openrtb-core/src/main/protobuf/openrtb.proto
@@ -991,6 +991,10 @@ message BidRequest {
     // Content language using ISO-639-1-alpha-2.
     optional string language = 19;
 
+    // Additional content data. Each Data object represents a different
+    // data source.
+    repeated Data data = 26;
+
     // Extensions.
     extensions 100 to 9999;
   }


### PR DESCRIPTION
For some reason this is missing in the forked repo. Beware, if Google adds it to their repo, it may have a different index.