### PR TITLE
Update to use com.google.protobuf version 3.22.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
     <injectVersion>1</injectVersion>
     <junitVersion>4.13</junitVersion>
     <metricsVersion>4.1.12.1</metricsVersion>
-    <protobufVersion>3.13.0</protobufVersion>
+    <protobufVersion>3.22.0</protobufVersion>
     <slf4jVersion>1.7.30</slf4jVersion>
     <truthVersion>1.0.1</truthVersion>
 


### PR DESCRIPTION
Update to com.google.protobuf version 3.22 to address compilation errors like this:
```
[ERROR] /Users/.../openrtb-proto-v2/openrtb-core/target/generated-sources/protobuf/com/iabtechlab/openrtb/v2/OpenRtb.java:[1372,50] emptyList() is not public in com.google.protobuf.LazyStringArrayList; cannot be accessed from outside package
```