### PR TITLE
Add back deprecated consent field

### DIFF
--- a/openrtb-core/src/main/protobuf/openrtb.proto
+++ b/openrtb-core/src/main/protobuf/openrtb.proto
@@ -1609,6 +1609,10 @@ message BidRequest {
 
     // When GDPR regulations are in effect this attribute contains the
     // Transparency and Consent Framework’s Consent String data structure.
+    optional string deprecated_consent = 9 [deprecated = true];
+
+    // When GDPR regulations are in effect this attribute contains the
+    // Transparency and Consent Framework’s Consent String data structure.
     optional string consent = 10;
 
     // Extensions.


### PR DESCRIPTION
This is to allow for proper transition to the index 10 `consent` field from the previous index 9 location removed by https://github.com/IABTechLab/openrtb-proto-v2/pull/31. Intention is to make index 9 reserved after transition.