### PR TITLE
Added a few fields required for full support for version 4.0 and more

### DIFF
--- a/openrtb-core/src/main/protobuf/openrtb-ext.proto
+++ b/openrtb-core/src/main/protobuf/openrtb-ext.proto
@@ -303,28 +303,6 @@ message SKAdNetworkFidelity {
   extensions 100 to 9999;
 }
 
-// SKAdNetwork SKOverlay attributes.
-message SKAdNetworkSKOverlay {
-  // Delay before presenting the SKOverlay in seconds.
-  // If set to 0, the overlay will be shown immediately.
-  // If this field is not set, the overlay will not be shown.
-  optional int32 delay = 1;
-
-  // Delay before presenting the SKOverlay on an endcard in seconds.
-  // If set to 0, the overlay will be shown immediately.
-  // If this field is not set, the overlay will not be shown.
-  optional int32 endcarddelay = 2;
-
-  // Whether the overlay can be dismissed by the user, where 0 = no, 1 = yes
-  optional bool dismissible = 3;
-
-  // Position of the Overlay. 0 = bottom, 1 = bottomRaised.
-  optional int32 pos = 4;
-
-  // Extensions.
-  extensions 100 to 9999;
-}
-
 // Advertiser's SKAdNetwork information to support app installation
 // attribution for iOS 14 and later.  Apple's SKAdNetwork API helps
 // advertisers measure ad-driven app installation by sending a postback
@@ -383,8 +361,29 @@ message SKAdNetworkResponse {
   // Custom Product Page ID (UUID).
   optional string productpageid = 11;
 
+  message SKOverlay {
+    // Delay before presenting the SKOverlay in seconds.
+    // If set to 0, the overlay will be shown immediately.
+    // If this field is not set, the overlay will not be shown.
+    optional int32 delay = 1;
+
+    // Delay before presenting the SKOverlay on an endcard in seconds.
+    // If set to 0, the overlay will be shown immediately.
+    // If this field is not set, the overlay will not be shown.
+    optional int32 endcarddelay = 2;
+
+    // Whether the overlay can be dismissed by the user, where 0 = no, 1 = yes
+    optional bool dismissible = 3;
+
+    // Position of the Overlay. 0 = bottom, 1 = bottomRaised.
+    optional int32 pos = 4;
+
+    // Extensions.
+    extensions 100 to 9999;
+  }
+
   // SKOverlay support.
-  optional SKAdNetworkSKOverlay skoverlay = 12;
+  optional SKOverlay skoverlay = 12;
 
   // Extensions.
   extensions 100 to 9999;

--- a/openrtb-core/src/main/protobuf/openrtb-ext.proto
+++ b/openrtb-core/src/main/protobuf/openrtb-ext.proto
@@ -219,6 +219,12 @@ message SKAdNetworkRequest {
   // "2.0" or higher. Dependent on both the OS version and the SDK version.
   repeated string versions = 5;
 
+  // Custom Product Page support.
+  optional int32 productpage = 6;
+
+  // SKOverlay support. If set, SKOverlay is supported.
+  optional int32 skoverlay = 7;
+
   // Extensions.
   extensions 100 to 9999;
 }
@@ -297,6 +303,28 @@ message SKAdNetworkFidelity {
   extensions 100 to 9999;
 }
 
+// SKAdNetwork SKOverlay attributes.
+message SKAdNetworkSKOverlay {
+  // Delay before presenting the SKOverlay in seconds.
+  // If set to 0, the overlay will be shown immediately.
+  // If this field is not set, the overlay will not be shown.
+  optional int32 delay = 1;
+
+  // Delay before presenting the SKOverlay on an endcard in seconds.
+  // If set to 0, the overlay will be shown immediately.
+  // If this field is not set, the overlay will not be shown.
+  optional int32 endcarddelay = 2;
+
+  // Whether the overlay can be dismissed by the user, where 0 = no, 1 = yes
+  optional int32 dismissible = 3;
+
+  // Position of the Overlay. 0 = bottom, 1 = bottomRaised.
+  optional int32 pos = 4;
+
+  // Extensions.
+  extensions 100 to 9999;
+}
+
 // Advertiser's SKAdNetwork information to support app installation
 // attribution for iOS 14 and later.  Apple's SKAdNetwork API helps
 // advertisers measure ad-driven app installation by sending a postback
@@ -346,6 +374,17 @@ message SKAdNetworkResponse {
 
   // Supports multiple fidelity types introduced in SKAdNetwork v2.2.
   repeated SKAdNetworkFidelity fidelities = 9;
+
+  // A four-digit integer that ad networks define to represent the ad campaign.
+  // Used in SKAdNetwork 4.0+, replaces Campaign ID `campaign`.
+  // DSPs must generate signatures in 4.0+ using the Source Identifier.
+  optional string sourceidentifier = 10;
+
+  // Custom Product Page ID (UUID).
+  optional string productpageid = 11;
+
+  // SKOverlay support.
+  optional SKAdNetworkSKOverlay skoverlay = 12;
 
   // Extensions.
   extensions 100 to 9999;

--- a/openrtb-core/src/main/protobuf/openrtb-ext.proto
+++ b/openrtb-core/src/main/protobuf/openrtb-ext.proto
@@ -220,10 +220,10 @@ message SKAdNetworkRequest {
   repeated string versions = 5;
 
   // Custom Product Page support.
-  optional int32 productpage = 6;
+  optional bool productpage = 6;
 
   // SKOverlay support. If set, SKOverlay is supported.
-  optional int32 skoverlay = 7;
+  optional bool skoverlay = 7;
 
   // Extensions.
   extensions 100 to 9999;
@@ -316,7 +316,7 @@ message SKAdNetworkSKOverlay {
   optional int32 endcarddelay = 2;
 
   // Whether the overlay can be dismissed by the user, where 0 = no, 1 = yes
-  optional int32 dismissible = 3;
+  optional bool dismissible = 3;
 
   // Position of the Overlay. 0 = bottom, 1 = bottomRaised.
   optional int32 pos = 4;


### PR DESCRIPTION
Add fields `productpage`, `skoverlay` for `BidRequest.imp.ext.skadn` object and `sourceidentifier`, `productpageid`, `skoverlay` for `BidResponse.seatbid.bid.ext.skadn` object.